### PR TITLE
Replace project icon border

### DIFF
--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -1159,8 +1159,8 @@ const collapsedChecklist = ref(false)
       margin-top: calc(-3rem - var(--spacing-card-lg) - 4px);
       margin-left: -4px;
       z-index: 1;
-      border: 4px solid var(--color-raised-bg);
-      border-bottom: none;
+      box-shadow: -2px -2px 0 2px var(--color-raised-bg),
+        2px -2px 0 2px var(--color-raised-bg);
     }
   }
   .project__header__content {


### PR DESCRIPTION
#1280

Projects with featured images have borders around their 96x96 icons, which squishes them to 88x92. This box-shadow replacement preserves the icon size while staying visually equivalent (rounded 4px border around left, top, and right).